### PR TITLE
Adds Parent Logger Relationship

### DIFF
--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -380,7 +380,7 @@ class Logger implements LoggerInterface
         }
 
         // Lets also propagate this to the parent, if it exists.
-        if ($this->parent != null) {
+        if ($this->parent !== null) {
             $this->parent->addRecord($level, $message, $context);
             // We return true here because at least one logger (this one) handled this record.
             return true;

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -120,6 +120,13 @@ class Logger implements LoggerInterface
     protected $handlers;
 
     /**
+     * The logger's parent logger
+     *
+     * @var Logger
+     */
+    protected $parent;
+
+    /**
      * Processors that will process all log records
      *
      * To process records of a single handler instead, add the processor on that specific handler
@@ -137,12 +144,18 @@ class Logger implements LoggerInterface
      * @param string             $name       The logging channel
      * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
      * @param callable[]         $processors Optional array of processors
+     * @param Logger             $parent     Optional logger parent
      */
-    public function __construct($name, array $handlers = array(), array $processors = array())
+    public function __construct(
+        $name,
+        array $handlers = array(),
+        array $processors = array(),
+        Logger $parent = null)
     {
         $this->name = $name;
         $this->handlers = $handlers;
         $this->processors = $processors;
+        $this->parent = $parent;
     }
 
     /**
@@ -217,6 +230,28 @@ class Logger implements LoggerInterface
     public function getHandlers()
     {
         return $this->handlers;
+    }
+
+    /**
+     * Set the parent logger. Will override any prior set parent logger.
+     *
+     * @param Logger $parent    Parent logger
+     * @return $this
+     */
+    public function setParent(Logger $parent)
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    /**
+     * Get the parent logger, if it exists.
+     *
+     * @return Logger
+     */
+    public function getParent()
+    {
+        return $this->parent;
     }
 
     /**
@@ -304,6 +339,10 @@ class Logger implements LoggerInterface
         }
 
         if (null === $handlerKey) {
+            // Check if a parent logger should handle this message as well.
+            if ($this->parent !== null) {
+                return $this->parent->addRecord($level, $message, $context);
+            }
             return false;
         }
 
@@ -339,6 +378,14 @@ class Logger implements LoggerInterface
 
             next($this->handlers);
         }
+
+        // Lets also propagate this to the parent, if it exists.
+        if ($this->parent != null) {
+            $this->parent->addRecord($level, $message, $context);
+            // We return true here because at least one logger (this one) handled this record.
+            return true;
+        }
+
 
         return true;
     }

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -13,6 +13,7 @@ namespace Monolog;
 
 use Monolog\Processor\WebProcessor;
 use Monolog\Handler\TestHandler;
+use Monolog\Handler\GroupHandler;
 
 class LoggerTest extends \PHPUnit_Framework_TestCase
 {
@@ -544,5 +545,180 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
             'with microseconds' => array(true, 'assertNotSame'),
             'without microseconds' => array(false, 'assertSame'),
         );
+    }
+
+    /**
+     * @covers Monolog\Logger::setParent
+     * @covers Monolog\Logger::getParent
+     */
+    public function testSetParent()
+    {
+        $parentLogger = new Logger('parent');
+        $childLogger = new Logger('child');
+        $this->assertNull($childLogger->getParent());
+        $childLogger->setParent($parentLogger);
+        $this->assertSame($parentLogger, $childLogger->getParent());
+    }
+
+    /**
+     * If we set a parent logger and one of our handlers is set to not bubble,
+     * we still expect the message to get sent to the parent logger. However,
+     * we do NOT expect the record to get processed by any handlers under the
+     * non-bubbling handler.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentIsCalledWhenHandlerNotBubble()
+    {
+        $parentLogger = new Logger('parent');
+        $bubblingParentHandler = new TestHandler();
+        $nonBubblingParentHandler = new Testhandler(Logger::INFO, false);
+        $parentLogger->pushHandler($bubblingParentHandler);
+        $parentLogger->pushHandler($nonBubblingParentHandler);
+
+        $childLogger = new Logger('child');
+        $bubblingChildHandler = new TestHandler();
+        $nonBubblingChildHandler = new TestHandler(Logger::INFO, false);
+        $childLogger->pushHandler($bubblingChildHandler);
+        $childLogger->pushHandler($nonBubblingChildHandler);
+
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+        $this->assertFalse($bubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertTrue($nonBubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertTrue($nonBubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertFalse($bubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+    }
+
+    /**
+     * If we set a parent logger and one of our handlers is set to not bubble,
+     * we still expect the message to get sent to the parent logger. However,
+     * we do NOT expect the record to get processed by any handlers under the
+     * non-bubbling handler.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentIsCalledWhenHandlerNotBubbleGroupHandlers()
+    {
+        $bubblingParentHandler = new TestHandler();
+        $nonBubblingParentHandler = new Testhandler(Logger::INFO, false);
+        $parentGroupHandler = new GroupHandler(
+            array(
+                $nonBubblingParentHandler,
+                $bubblingParentHandler,
+            )
+        );
+
+        $childLogger = new Logger('child');
+        $bubblingChildHandler = new TestHandler();
+        $nonBubblingChildHandler = new TestHandler(Logger::INFO, false);
+        $childGroupHandler = new GroupHandler(
+            array(
+                $nonBubblingChildHandler,
+                $bubblingChildHandler,
+            )
+        );
+
+        $childLogger->pushHandler($parentGroupHandler);
+        $childLogger->pushHandler($childGroupHandler);
+
+        $this->assertTrue($childLogger->warn('foo'));
+        $this->assertFalse($bubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertTrue($nonBubblingChildHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertTrue($nonBubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $this->assertFalse($bubblingParentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+    }
+
+    /**
+     * Processors of a parent logger should only apply to the parent's handlers.
+     * A child loggers processor should not apply to messages processed by the parent.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentProcessorsAppliedToParentHandlers()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentProcessor = function ($record) {
+            $record['extra']['key'] = 'parent';
+            return $record;
+        };
+        $parentLogger->pushHandler($parentHandler);
+        $parentLogger->pushProcessor($parentProcessor);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler();
+        $childProcessor = function ($record) {
+            $record['extra']['key'] = 'child';
+            return $record;
+        };
+        $childLogger->pushHandler($childHandler);
+        $childLogger->pushProcessor($childProcessor);
+
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertEquals(array('key' => 'parent'), $parentRecords[0]['extra']);
+        $childRecords = $childHandler->getRecords();
+        $this->assertCount(1, $childRecords);
+        $this->assertEquals(array('key' => 'child'), $childRecords[0]['extra']);
+    }
+
+    /**
+     * If a logger has no handler which would precess a message due to the message
+     * being at a level too low for any of the logger's handlers, typically the
+     * logger returns false. However, if the logger has a parent, we should pass the
+     * message to the parent first to give it the chance to handle the message.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsIfChildHandlerNotProcessRecord()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler(Logger::EMERGENCY);
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $childRecords = $childHandler->getRecords();
+        $this->assertCount(0, $childRecords);
+        $this->assertFalse($childHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+    }
+
+    /**
+     * If no handler on a logger or any of its parents handles a message, we should
+     * return false.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testLoggerReturnsFalseIfNoLoggerHandlesMessage()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler(Logger::EMERGENCY);
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler(Logger::EMERGENCY);
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertFalse($childLogger->warn('foo'));
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(0, $parentRecords);
+        $this->assertFalse($parentHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+        $childRecords = $childHandler->getRecords();
+        $this->assertCount(0, $childRecords);
+        $this->assertFalse($childHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
+
     }
 }


### PR DESCRIPTION
With this diff, we will now be able to pass in a parent logger to any logger. Log messages will get passed to the parent logger by default.
