### PR TITLE
Added support for runtime options

### DIFF
--- a/src/Monolog/Registry.php
+++ b/src/Monolog/Registry.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 /**
  * Monolog log registry
  *
- * Allows to get `Logger` instances in the global scope
+ * Allows to get `Logger` instances and run-time options in the global scope
  * via static method calls on this class.
  *
  * <code>
@@ -45,6 +45,13 @@ class Registry
     private static $loggers = array();
 
     /**
+     * List of all run-time config options for loggers
+     *
+     * @var array()
+     */
+    private static $options = array();
+
+    /**
      * Adds new logging channel to the registry
      *
      * @param  Logger                    $logger    Instance of the logging channel
@@ -64,6 +71,17 @@ class Registry
     }
 
     /**
+     * Adds new run-time logging option to the registry
+     *
+     * @param  string $key    Instance of the logging channel
+     * @param  bool|int|string $value
+     */
+    public static function addOption($key, $value = true)
+    {
+        self::$options[$key] = $value;
+    }
+
+    /**
      * Checks if such logging channel exists by name or instance
      *
      * @param string|Logger $logger Name or logger instance
@@ -77,6 +95,17 @@ class Registry
         } else {
             return isset(self::$loggers[$logger]);
         }
+    }
+
+    /**
+     * Checks if such run-time option exists
+     *
+     * @param string $name key of the option
+     * @return bool
+     */
+    public static function hasOption($name)
+    {
+        return isset(self::$options[$name]);
     }
 
     /**
@@ -96,7 +125,7 @@ class Registry
     }
 
     /**
-     * Clears the registry
+     * Clears the registry of loggers
      */
     public static function clear()
     {
@@ -117,6 +146,22 @@ class Registry
         }
 
         return self::$loggers[$name];
+    }
+
+    /**
+     * Gets run-time option from the registry
+     *
+     * @param  string $name              Name of the requested run-time option
+     * @throws \InvalidArgumentException If named option is not in the registry
+     * @return bool|int|string           Value of requested run-time option
+     */
+    public static function getOption($name)
+    {
+        if (!isset(self::$options[$name])) {
+            throw new InvalidArgumentException(sprintf('Requested "%s" option is not in the registry', $name));
+        }
+
+        return self::$options[$name];
     }
 
     /**

--- a/tests/Monolog/RegistryTest.php
+++ b/tests/Monolog/RegistryTest.php
@@ -150,4 +150,33 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
 
         Registry::addLogger($log2, 'log');
     }
+
+    /**
+     * @covers Monolog\Registry::addOption
+     * @covers Monolog\Registry::hasOption
+     * @covers Monolog\Registry::getOption
+     */
+    public function testAddOption()
+    {
+        $option1 = 'string';
+        $option2 = false;
+        $option3 = 6;
+        $option4 = true;
+
+        Registry::addOption('option1', 'string');
+        Registry::addOption('option2', false);
+        Registry::addOption('option3', 6);
+        Registry::addOption('option4'); // Should be true by default
+
+        $this->assertSame(true, Registry::hasOption('option1'));
+        $this->assertSame(true, Registry::hasOption('option2'));
+        $this->assertSame(true, Registry::hasOption('option3'));
+        $this->assertSame(true, Registry::hasOption('option4'));
+        $this->assertSame(false, Registry::hasOption('option5'));
+
+        $this->assertSame($option1, Registry::getOption('option1'));
+        $this->assertSame($option2, Registry::getOption('option2'));
+        $this->assertSame($option3, Registry::getOption('option3'));
+        $this->assertSame($option4, Registry::getOption('option4'));
+    }
 }


### PR DESCRIPTION
The purpose of this commit is to allow support for access to set and get run-time options. Extensions of Monolog, such as Cascade, will need to set a run-time options from a config file and access it after parsing and losing access to the config file. 
