### PR TITLE
Feature - Propagate source name

### DIFF
--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -135,6 +135,7 @@ class TestHandler extends AbstractProcessingHandler
         }, $level);
     }
 
+
     /**
      * {@inheritdoc}
      */

--- a/src/Monolog/Handler/TestHandler.php
+++ b/src/Monolog/Handler/TestHandler.php
@@ -128,6 +128,13 @@ class TestHandler extends AbstractProcessingHandler
         return false;
     }
 
+    public function hasRecordWithSource($source, $level)
+    {
+        return $this->hasRecordThatPasses(function ($rec) use ($source) {
+            return $source === $rec['channel'];
+        }, $level);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -313,13 +313,16 @@ class Logger implements LoggerInterface
     /**
      * Adds a log record.
      *
-     * @param  int     $level   The logging level
-     * @param  string  $message The log message
-     * @param  array   $context The log context
+     * @param  int     $level         The logging level
+     * @param  string  $message       The log message
+     * @param  array   $context       The log context
+     * @param  string  $sourceChannel The original source of the log message
      * @return Boolean Whether the record has been processed
      */
     public function addRecord($level, $message, array $context = array(), $sourceChannel = null)
     {
+        $sourceChannel ?: $this->name;
+
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
         }
@@ -341,9 +344,6 @@ class Logger implements LoggerInterface
         if (null === $handlerKey) {
             // Check if a parent logger should handle this message as well.
             if ($this->parent !== null) {
-                if ($sourceChannel === null) {
-                    $sourceChannel = $this->name;
-                }
                 return $this->parent->addRecord($level, $message, $context, $sourceChannel);
             }
             return false;
@@ -365,7 +365,7 @@ class Logger implements LoggerInterface
             'context' => $context,
             'level' => $level,
             'level_name' => $levelName,
-            'channel' => $sourceChannel !== null ? $sourceChannel : $this->name,
+            'channel' => $sourceChannel,
             'datetime' => $ts,
             'extra' => array(),
         );
@@ -384,9 +384,6 @@ class Logger implements LoggerInterface
 
         // Lets also propagate this to the parent, if it exists.
         if ($this->parent !== null) {
-            if ($sourceChannel === null) {
-                $sourceChannel = $this->name;
-            }
             $this->parent->addRecord($level, $message, $context, $sourceChannel);
             // We return true here because at least one logger (this one) handled this record.
             return true;

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -316,9 +316,10 @@ class Logger implements LoggerInterface
      * @param  int     $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The name of the original channel the log came from
      * @return Boolean Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = array())
+    public function addRecord($level, $message, array $context = array(), $source = null)
     {
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
@@ -341,7 +342,10 @@ class Logger implements LoggerInterface
         if (null === $handlerKey) {
             // Check if a parent logger should handle this message as well.
             if ($this->parent !== null) {
-                return $this->parent->addRecord($level, $message, $context);
+                if ($source === null) {
+                    $source = $this->name;
+                }
+                return $this->parent->addRecord($level, $message, $context, $source);
             }
             return false;
         }
@@ -362,7 +366,7 @@ class Logger implements LoggerInterface
             'context' => $context,
             'level' => $level,
             'level_name' => $levelName,
-            'channel' => $this->name,
+            'channel' => $source !== null ? $source : $this->name,
             'datetime' => $ts,
             'extra' => array(),
         );
@@ -381,7 +385,10 @@ class Logger implements LoggerInterface
 
         // Lets also propagate this to the parent, if it exists.
         if ($this->parent !== null) {
-            $this->parent->addRecord($level, $message, $context);
+            if ($source === null) {
+                $source = $this->name;
+            }
+            $this->parent->addRecord($level, $message, $context, $source);
             // We return true here because at least one logger (this one) handled this record.
             return true;
         }
@@ -395,11 +402,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array())
+    public function addDebug($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::DEBUG, $message, $context);
+        return $this->addRecord(static::DEBUG, $message, $context, $source);
     }
 
     /**
@@ -407,11 +415,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array())
+    public function addInfo($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::INFO, $message, $context);
+        return $this->addRecord(static::INFO, $message, $context, $source);
     }
 
     /**
@@ -419,11 +428,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array())
+    public function addNotice($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::NOTICE, $message, $context);
+        return $this->addRecord(static::NOTICE, $message, $context, $source);
     }
 
     /**
@@ -431,11 +441,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array())
+    public function addWarning($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $source);
     }
 
     /**
@@ -443,11 +454,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array())
+    public function addError($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $source);
     }
 
     /**
@@ -455,11 +467,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array())
+    public function addCritical($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $source);
     }
 
     /**
@@ -467,11 +480,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array())
+    public function addAlert($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::ALERT, $message, $context);
+        return $this->addRecord(static::ALERT, $message, $context, $source);
     }
 
     /**
@@ -479,11 +493,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addEmergency($message, array $context = array())
+    public function addEmergency($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
     }
 
     /**
@@ -555,13 +570,14 @@ class Logger implements LoggerInterface
      * @param  mixed   $level   The log level
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array(), $source = null)
     {
         $level = static::toMonologLevel($level);
 
-        return $this->addRecord($level, $message, $context);
+        return $this->addRecord($level, $message, $context, $source);
     }
 
     /**
@@ -571,11 +587,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::DEBUG, $message, $context);
+        return $this->addRecord(static::DEBUG, $message, $context, $source);
     }
 
     /**
@@ -585,11 +602,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function info($message, array $context = array())
+    public function info($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::INFO, $message, $context);
+        return $this->addRecord(static::INFO, $message, $context, $source);
     }
 
     /**
@@ -599,11 +617,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::NOTICE, $message, $context);
+        return $this->addRecord(static::NOTICE, $message, $context, $source);
     }
 
     /**
@@ -613,11 +632,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warn($message, array $context = array())
+    public function warn($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $source);
     }
 
     /**
@@ -627,11 +647,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context);
+        return $this->addRecord(static::WARNING, $message, $context, $source);
     }
 
     /**
@@ -641,11 +662,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function err($message, array $context = array())
+    public function err($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $source);
     }
 
     /**
@@ -655,11 +677,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function error($message, array $context = array())
+    public function error($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context);
+        return $this->addRecord(static::ERROR, $message, $context, $source);
     }
 
     /**
@@ -669,11 +692,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function crit($message, array $context = array())
+    public function crit($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $source);
     }
 
     /**
@@ -683,11 +707,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context);
+        return $this->addRecord(static::CRITICAL, $message, $context, $source);
     }
 
     /**
@@ -697,11 +722,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::ALERT, $message, $context);
+        return $this->addRecord(static::ALERT, $message, $context, $source);
     }
 
     /**
@@ -711,11 +737,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emerg($message, array $context = array())
+    public function emerg($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
     }
 
     /**
@@ -725,11 +752,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
+     * @param  string  $source  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = array(), $source = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -316,7 +316,6 @@ class Logger implements LoggerInterface
      * @param  int     $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The name of the original channel the log came from
      * @return Boolean Whether the record has been processed
      */
     public function addRecord($level, $message, array $context = array(), $sourceChannel = null)
@@ -402,12 +401,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array(), $sourceChannel = null)
+    public function addDebug($message, array $context = array())
     {
-        return $this->addRecord(static::DEBUG, $message, $context, $sourceChannel);
+        return $this->addRecord(static::DEBUG, $message, $context, $this->name);
     }
 
     /**
@@ -415,12 +413,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array(), $sourceChannel = null)
+    public function addInfo($message, array $context = array())
     {
-        return $this->addRecord(static::INFO, $message, $context, $sourceChannel);
+        return $this->addRecord(static::INFO, $message, $context, $this->name);
     }
 
     /**
@@ -428,12 +425,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array(), $sourceChannel = null)
+    public function addNotice($message, array $context = array())
     {
-        return $this->addRecord(static::NOTICE, $message, $context, $sourceChannel);
+        return $this->addRecord(static::NOTICE, $message, $context, $this->name);
     }
 
     /**
@@ -441,12 +437,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array(), $sourceChannel = null)
+    public function addWarning($message, array $context = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
+        return $this->addRecord(static::WARNING, $message, $context, $this->name);
     }
 
     /**
@@ -454,12 +449,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array(), $sourceChannel = null)
+    public function addError($message, array $context = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
+        return $this->addRecord(static::ERROR, $message, $context, $this->name);
     }
 
     /**
@@ -467,12 +461,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array(), $sourceChannel = null)
+    public function addCritical($message, array $context = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
+        return $this->addRecord(static::CRITICAL, $message, $context, $this->name);
     }
 
     /**
@@ -480,12 +473,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array(), $sourceChannel = null)
+    public function addAlert($message, array $context = array())
     {
-        return $this->addRecord(static::ALERT, $message, $context, $sourceChannel);
+        return $this->addRecord(static::ALERT, $message, $context, $this->name);
     }
 
     /**
@@ -493,12 +485,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addEmergency($message, array $context = array(), $sourceChannel = null)
+    public function addEmergency($message, array $context = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $this->name);
     }
 
     /**
@@ -570,14 +561,13 @@ class Logger implements LoggerInterface
      * @param  mixed   $level   The log level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function log($level, $message, array $context = array(), $sourceChannel = null)
+    public function log($level, $message, array $context = array())
     {
         $level = static::toMonologLevel($level);
 
-        return $this->addRecord($level, $message, $context, $sourceChannel);
+        return $this->addRecord($level, $message, $context, $this->name);
     }
 
     /**
@@ -587,12 +577,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function debug($message, array $context = array(), $sourceChannel = null)
+    public function debug($message, array $context = array())
     {
-        return $this->addRecord(static::DEBUG, $message, $context, $sourceChannel);
+        return $this->addRecord(static::DEBUG, $message, $context, $this->name);
     }
 
     /**
@@ -602,12 +591,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function info($message, array $context = array(), $sourceChannel = null)
+    public function info($message, array $context = array())
     {
-        return $this->addRecord(static::INFO, $message, $context, $sourceChannel);
+        return $this->addRecord(static::INFO, $message, $context, $this->name);
     }
 
     /**
@@ -617,12 +605,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function notice($message, array $context = array(), $sourceChannel = null)
+    public function notice($message, array $context = array())
     {
-        return $this->addRecord(static::NOTICE, $message, $context, $sourceChannel);
+        return $this->addRecord(static::NOTICE, $message, $context, $this->name);
     }
 
     /**
@@ -632,12 +619,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warn($message, array $context = array(), $sourceChannel = null)
+    public function warn($message, array $context = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
+        return $this->addRecord(static::WARNING, $message, $context, $this->name);
     }
 
     /**
@@ -647,12 +633,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warning($message, array $context = array(), $sourceChannel = null)
+    public function warning($message, array $context = array())
     {
-        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
+        return $this->addRecord(static::WARNING, $message, $context, $this->name);
     }
 
     /**
@@ -662,12 +647,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function err($message, array $context = array(), $sourceChannel = null)
+    public function err($message, array $context = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
+        return $this->addRecord(static::ERROR, $message, $context, $this->name);
     }
 
     /**
@@ -677,12 +661,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function error($message, array $context = array(), $sourceChannel = null)
+    public function error($message, array $context = array())
     {
-        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
+        return $this->addRecord(static::ERROR, $message, $context, $this->name);
     }
 
     /**
@@ -692,12 +675,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function crit($message, array $context = array(), $sourceChannel = null)
+    public function crit($message, array $context = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
+        return $this->addRecord(static::CRITICAL, $message, $context, $this->name);
     }
 
     /**
@@ -707,12 +689,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function critical($message, array $context = array(), $sourceChannel = null)
+    public function critical($message, array $context = array())
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
+        return $this->addRecord(static::CRITICAL, $message, $context, $this->name);
     }
 
     /**
@@ -722,12 +703,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function alert($message, array $context = array(), $sourceChannel = null)
+    public function alert($message, array $context = array())
     {
-        return $this->addRecord(static::ALERT, $message, $context, $sourceChannel);
+        return $this->addRecord(static::ALERT, $message, $context, $this->name);
     }
 
     /**
@@ -737,12 +717,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emerg($message, array $context = array(), $sourceChannel = null)
+    public function emerg($message, array $context = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $this->name);
     }
 
     /**
@@ -752,12 +731,11 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emergency($message, array $context = array(), $sourceChannel = null)
+    public function emergency($message, array $context = array())
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $this->name);
     }
 
     /**

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -316,10 +316,10 @@ class Logger implements LoggerInterface
      * @param  int     $level   The logging level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The name of the original channel the log came from
+     * @param  string  $sourceChannel  The name of the original channel the log came from
      * @return Boolean Whether the record has been processed
      */
-    public function addRecord($level, $message, array $context = array(), $source = null)
+    public function addRecord($level, $message, array $context = array(), $sourceChannel = null)
     {
         if (!$this->handlers) {
             $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
@@ -342,10 +342,10 @@ class Logger implements LoggerInterface
         if (null === $handlerKey) {
             // Check if a parent logger should handle this message as well.
             if ($this->parent !== null) {
-                if ($source === null) {
-                    $source = $this->name;
+                if ($sourceChannel === null) {
+                    $sourceChannel = $this->name;
                 }
-                return $this->parent->addRecord($level, $message, $context, $source);
+                return $this->parent->addRecord($level, $message, $context, $sourceChannel);
             }
             return false;
         }
@@ -366,7 +366,7 @@ class Logger implements LoggerInterface
             'context' => $context,
             'level' => $level,
             'level_name' => $levelName,
-            'channel' => $source !== null ? $source : $this->name,
+            'channel' => $sourceChannel !== null ? $sourceChannel : $this->name,
             'datetime' => $ts,
             'extra' => array(),
         );
@@ -385,10 +385,10 @@ class Logger implements LoggerInterface
 
         // Lets also propagate this to the parent, if it exists.
         if ($this->parent !== null) {
-            if ($source === null) {
-                $source = $this->name;
+            if ($sourceChannel === null) {
+                $sourceChannel = $this->name;
             }
-            $this->parent->addRecord($level, $message, $context, $source);
+            $this->parent->addRecord($level, $message, $context, $sourceChannel);
             // We return true here because at least one logger (this one) handled this record.
             return true;
         }
@@ -402,12 +402,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addDebug($message, array $context = array(), $source = null)
+    public function addDebug($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::DEBUG, $message, $context, $source);
+        return $this->addRecord(static::DEBUG, $message, $context, $sourceChannel);
     }
 
     /**
@@ -415,12 +415,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addInfo($message, array $context = array(), $source = null)
+    public function addInfo($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::INFO, $message, $context, $source);
+        return $this->addRecord(static::INFO, $message, $context, $sourceChannel);
     }
 
     /**
@@ -428,12 +428,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addNotice($message, array $context = array(), $source = null)
+    public function addNotice($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::NOTICE, $message, $context, $source);
+        return $this->addRecord(static::NOTICE, $message, $context, $sourceChannel);
     }
 
     /**
@@ -441,12 +441,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addWarning($message, array $context = array(), $source = null)
+    public function addWarning($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context, $source);
+        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
     }
 
     /**
@@ -454,12 +454,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addError($message, array $context = array(), $source = null)
+    public function addError($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context, $source);
+        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
     }
 
     /**
@@ -467,12 +467,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addCritical($message, array $context = array(), $source = null)
+    public function addCritical($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $source);
+        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
     }
 
     /**
@@ -480,12 +480,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addAlert($message, array $context = array(), $source = null)
+    public function addAlert($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::ALERT, $message, $context, $source);
+        return $this->addRecord(static::ALERT, $message, $context, $sourceChannel);
     }
 
     /**
@@ -493,12 +493,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function addEmergency($message, array $context = array(), $source = null)
+    public function addEmergency($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
     }
 
     /**
@@ -570,14 +570,14 @@ class Logger implements LoggerInterface
      * @param  mixed   $level   The log level
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function log($level, $message, array $context = array(), $source = null)
+    public function log($level, $message, array $context = array(), $sourceChannel = null)
     {
         $level = static::toMonologLevel($level);
 
-        return $this->addRecord($level, $message, $context, $source);
+        return $this->addRecord($level, $message, $context, $sourceChannel);
     }
 
     /**
@@ -587,12 +587,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function debug($message, array $context = array(), $source = null)
+    public function debug($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::DEBUG, $message, $context, $source);
+        return $this->addRecord(static::DEBUG, $message, $context, $sourceChannel);
     }
 
     /**
@@ -602,12 +602,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function info($message, array $context = array(), $source = null)
+    public function info($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::INFO, $message, $context, $source);
+        return $this->addRecord(static::INFO, $message, $context, $sourceChannel);
     }
 
     /**
@@ -617,12 +617,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function notice($message, array $context = array(), $source = null)
+    public function notice($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::NOTICE, $message, $context, $source);
+        return $this->addRecord(static::NOTICE, $message, $context, $sourceChannel);
     }
 
     /**
@@ -632,12 +632,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warn($message, array $context = array(), $source = null)
+    public function warn($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context, $source);
+        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
     }
 
     /**
@@ -647,12 +647,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function warning($message, array $context = array(), $source = null)
+    public function warning($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::WARNING, $message, $context, $source);
+        return $this->addRecord(static::WARNING, $message, $context, $sourceChannel);
     }
 
     /**
@@ -662,12 +662,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function err($message, array $context = array(), $source = null)
+    public function err($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context, $source);
+        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
     }
 
     /**
@@ -677,12 +677,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function error($message, array $context = array(), $source = null)
+    public function error($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::ERROR, $message, $context, $source);
+        return $this->addRecord(static::ERROR, $message, $context, $sourceChannel);
     }
 
     /**
@@ -692,12 +692,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function crit($message, array $context = array(), $source = null)
+    public function crit($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $source);
+        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
     }
 
     /**
@@ -707,12 +707,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function critical($message, array $context = array(), $source = null)
+    public function critical($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::CRITICAL, $message, $context, $source);
+        return $this->addRecord(static::CRITICAL, $message, $context, $sourceChannel);
     }
 
     /**
@@ -722,12 +722,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function alert($message, array $context = array(), $source = null)
+    public function alert($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::ALERT, $message, $context, $source);
+        return $this->addRecord(static::ALERT, $message, $context, $sourceChannel);
     }
 
     /**
@@ -737,12 +737,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emerg($message, array $context = array(), $source = null)
+    public function emerg($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
     }
 
     /**
@@ -752,12 +752,12 @@ class Logger implements LoggerInterface
      *
      * @param  string  $message The log message
      * @param  array   $context The log context
-     * @param  string  $source  The original source of the log message
+     * @param  string  $sourceChannel  The original source of the log message
      * @return Boolean Whether the record has been processed
      */
-    public function emergency($message, array $context = array(), $source = null)
+    public function emergency($message, array $context = array(), $sourceChannel = null)
     {
-        return $this->addRecord(static::EMERGENCY, $message, $context, $source);
+        return $this->addRecord(static::EMERGENCY, $message, $context, $sourceChannel);
     }
 
     /**

--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -572,7 +572,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     {
         $parentLogger = new Logger('parent');
         $bubblingParentHandler = new TestHandler();
-        $nonBubblingParentHandler = new Testhandler(Logger::INFO, false);
+        $nonBubblingParentHandler = new TestHandler(Logger::INFO, false);
         $parentLogger->pushHandler($bubblingParentHandler);
         $parentLogger->pushHandler($nonBubblingParentHandler);
 
@@ -601,7 +601,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testParentIsCalledWhenHandlerNotBubbleGroupHandlers()
     {
         $bubblingParentHandler = new TestHandler();
-        $nonBubblingParentHandler = new Testhandler(Logger::INFO, false);
+        $nonBubblingParentHandler = new TestHandler(Logger::INFO, false);
         $parentGroupHandler = new GroupHandler(
             array(
                 $nonBubblingParentHandler,
@@ -723,4 +723,173 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($childHandler->hasRecordThatMatches('/^foo$/', Logger::WARNING));
 
     }
+
+    /**
+     * When a parent logger inherits from a child, its handler should print
+     * the original source (the child), not the parents name.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithChildsName()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler();
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+    }
+
+    /**
+     * When a parent logger inherits from a child, its handler should print
+     * the original source (the child), not the parents name.
+     * This should work when the child is not handled.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithChildsNameWhenChildNotHandled()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler(Logger::EMERGENCY);
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+    }
+
+    /**
+     * When a parent logger inherits from a child, its handler should print
+     * the original source (the child), not the parents name.
+     * This should work when the child is handled.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithChildsNameWhenChildHandled() {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler(Logger::WARNING);
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+
+        $childRecords = $childHandler->getRecords();
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+    }
+    /**
+     * When a parent logger inherits from a grandchild, its handler should print
+     * the original source (the grandchild), not the parents name or the child's name.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithGrandChildsName()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler();
+        $childLogger->pushHandler($childHandler);
+        $childLogger->setParent($parentLogger);
+
+        $grandchildLogger = new Logger('grandchild');
+        $grandchildLogger->pushHandler(new TestHandler(Logger::EMERGENCY));
+        $grandchildLogger->setParent($childLogger);
+
+        $this->assertTrue($grandchildLogger->warn('foo'));
+
+        $childRecords = $childHandler->getRecords();
+        $this->assertCount(1, $childRecords);
+        $this->assertTrue($childHandler->hasRecordWithSource('grandchild', Logger::WARNING));
+        $this->assertFalse($childHandler->hasRecordWithSource('parent', Logger::WARNING));
+        $this->assertFalse($childHandler->hasRecordWithSource('child', Logger::WARNING));
+
+        $grandparentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $grandparentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('grandchild', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+    }
+
+    /**
+     * When a parent logger inherits from a child, its handler should print
+     * the original source (the child), not the parents name. Bubble behavior
+     * should not effect this.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithChildsNameWhenBubbleIsFalse()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+
+        $childLogger = new Logger('child');
+        $childLogger->pushHandler(new TestHandler(Logger::WARNING, false));
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+    }
+
+
+    /**
+     * When a parent logger inherits from a child, its handler should print
+     * the original source (the child), not the parents name.
+     * Multiple handlers should not affect this behavior.
+     *
+     * @covers Monolog\Logger::addRecord
+     */
+    public function testParentLogsWithChildsNameWhenMultipleHandlers()
+    {
+        $parentLogger = new Logger('parent');
+        $parentHandler = new TestHandler();
+        $parentHandler2 = new TestHandler();
+        $parentLogger->pushHandler($parentHandler);
+        $parentLogger->pushHandler($parentHandler2);
+
+        $childLogger = new Logger('child');
+        $childHandler = new TestHandler(Logger::EMERGENCY);
+        $childHandler2 = new TestHandler(Logger::CRITICAL);
+        $childLogger->pushHandler($childHandler);
+        $childLogger->pushHandler($childHandler2);
+        $childLogger->setParent($parentLogger);
+
+        $this->assertTrue($childLogger->warn('foo'));
+
+        $parentRecords = $parentHandler->getRecords();
+        $this->assertCount(1, $parentRecords);
+        $this->assertTrue($parentHandler->hasRecordWithSource('child', Logger::WARNING));
+        $this->assertFalse($parentHandler->hasRecordWithSource('parent', Logger::WARNING));
+    }
+
 }


### PR DESCRIPTION
When `Foo` inherits from `Foo.Bar`, the log message should print its channel as `Foo.Bar`.
